### PR TITLE
fix(makefile): corrigir duplicação de diretório e verificação de configs/

### DIFF
--- a/Customizacao-hardening/CHANGELOG.md
+++ b/Customizacao-hardening/CHANGELOG.md
@@ -1,6 +1,13 @@
 # 📦 Changelog - Customização & Hardening
 
 Todas as mudanças importantes neste projeto serão documentadas aqui.
+## [2025-07-12] Correção de Makefile
+
+### Corrigido
+- Verificação da existência do diretório `configs/` antes de copiar com `cp -r`, evitando erro quando o diretório não existe.
+- Corrigida duplicação de diretório `Customizacao-hardening/Customizacao-hardening/` durante a instalação com `make install`.
+
+🔗 Relacionado à [Issue #5](https://github.com/rafaelmarzulo/Customizacao-hardening/issues/5)
 
 ## [2.0.0] - 2025-07-08
 ### Adicionado

--- a/Customizacao-hardening/Makefile
+++ b/Customizacao-hardening/Makefile
@@ -23,8 +23,8 @@ help:
 install:
 	@echo "Instalando $(PROJECT_NAME)..."
 	sudo mkdir -p $(INSTALL_DIR) $(CONFIG_DIR) $(LOG_DIR)
-	sudo cp -r scripts/ $(INSTALL_DIR)/
-	sudo cp -r configs/ $(CONFIG_DIR)/
+	sudo cp -r scripts/ Makefile config.yaml $(INSTALL_DIR)/
+	[ -d configs ] && sudo cp -r configs/ $(CONFIG_DIR)/
 	sudo chmod +x $(INSTALL_DIR)/scripts/*/*.sh
 	sudo ln -sf $(INSTALL_DIR)/scripts/hardening/ssh_hardening.sh /usr/local/bin/ssh-hardening
 	sudo ln -sf $(INSTALL_DIR)/scripts/setup/server_setup.sh /usr/local/bin/server-setup


### PR DESCRIPTION
### ✅ Descrição

Este PR corrige dois problemas no processo de instalação via `make install`:

- Evita erro ao tentar copiar `configs/` quando o diretório não existe.
- Corrige a duplicação do diretório `Customizacao-hardening/Customizacao-hardening/` ao copiar para `/opt`.

### 🔧 Alterações realizadas

- `Makefile`: adicionada verificação `-d configs` antes de copiar
- `Makefile`: ajustado `cp` para copiar apenas `scripts`, `Makefile`, e `config.yaml` para o diretório destino

🔗 Relacionado à [Issue #5](https://github.com/rafaelmarzulo/Customizacao-hardening/issues/5)
